### PR TITLE
feat(snap): add PERPENDICULAR and TANGENT snap types

### DIFF
--- a/packages/sdk-react/src/tools/snap-engine.ts
+++ b/packages/sdk-react/src/tools/snap-engine.ts
@@ -20,7 +20,9 @@ export const SNAP_TYPES = {
   MIDPOINT: "midpoint",
   INTERSECTION: "intersection",
   CENTER: "center",
-  NEAREST: "nearest"
+  NEAREST: "nearest",
+  PERPENDICULAR: "perpendicular",
+  TANGENT: "tangent"
 } as const;
 
 export type SnapType = (typeof SNAP_TYPES)[keyof typeof SNAP_TYPES];
@@ -33,7 +35,9 @@ const SNAP_PRIORITY: Record<SnapType, number> = {
   [SNAP_TYPES.MIDPOINT]: 80,
   [SNAP_TYPES.INTERSECTION]: 90,
   [SNAP_TYPES.CENTER]: 70,
-  [SNAP_TYPES.NEAREST]: 50
+  [SNAP_TYPES.NEAREST]: 50,
+  [SNAP_TYPES.PERPENDICULAR]: 85,
+  [SNAP_TYPES.TANGENT]: 75
 };
 
 export interface Point {
@@ -73,6 +77,30 @@ export interface SnapEngineOptions {
  */
 function distance(p1: Point, p2: Point): number {
   return Math.hypot(p2.x - p1.x, p2.y - p1.y);
+}
+
+/**
+ * 점에서 선까지의 수직 거리를 계산합니다.
+ */
+function perpendicularDistance(point: Point, lineStart: Point, lineEnd: Point): number {
+  const dx = lineEnd.x - lineStart.x;
+  const dy = lineEnd.y - lineStart.y;
+  const len = Math.hypot(dx, dy);
+  if (len < 1e-10) return distance(point, lineStart);
+  return Math.abs((dy * point.x - dx * point.y + lineEnd.x * lineStart.y - lineEnd.y * lineStart.x) / len);
+}
+
+/**
+ * 점에서 원까지의 접선 거리를 계산합니다.
+ */
+function tangentDistance(point: Point, center: Point, radius: number): number {
+  const d = distance(point, center);
+  if (d < radius) return 0;
+  const angle = Math.asin(radius / d);
+  return distance(point, {
+    x: center.x + radius * Math.cos(Math.atan2(point.y - center.y, point.x - center.x) + angle),
+    y: center.y + radius * Math.sin(Math.atan2(point.y - center.y, point.x - center.x) + angle)
+  });
 }
 
 /**
@@ -169,7 +197,7 @@ function getMidpointSnapPoints(entity: Entity): Point[] {
 }
 
 /**
- * 엔티티 쌍에서 교차점 스냅 포인트를 계산합니다.
+ * 엔티티에서 교차점 스냅 포인트를 계산합니다.
  */
 function getIntersectionSnapPoints(entity1: Entity, entity2: Entity): Point[] {
   const intersections: Point[] = [];
@@ -220,6 +248,81 @@ function getIntersectionSnapPoints(entity1: Entity, entity2: Entity): Point[] {
   }
 
   return intersections;
+}
+
+/**
+ * 엔티티에서 PERPENDICULAR(수직) 스냅 포인트를 계산합니다.
+ */
+function getPerpendicularSnapPoints(entity: Entity, fromPoint: Point): Point[] {
+  switch (entity.type) {
+    case "LINE":
+      if (entity.start && entity.end) {
+        const dx = entity.end.x - entity.start.x;
+        const dy = entity.end.y - entity.start.y;
+        const len = Math.hypot(dx, dy);
+        if (len < 1e-10) return [];
+        const t = Math.max(0, Math.min(1, ((fromPoint.x - entity.start.x) * dx + (fromPoint.y - entity.start.y) * dy) / (len * len)));
+        return [{
+          x: entity.start.x + t * dx,
+          y: entity.start.y + t * dy
+        }];
+      }
+      return [];
+    case "POLYLINE":
+    case "LWPOLYLINE":
+      if (!entity.vertices) return [];
+      const points: Point[] = [];
+      for (let i = 0; i < entity.vertices.length - 1; i++) {
+        const dx = entity.vertices[i + 1].x - entity.vertices[i].x;
+        const dy = entity.vertices[i + 1].y - entity.vertices[i].y;
+        const len = Math.hypot(dx, dy);
+        if (len < 1e-10) continue;
+        const t = Math.max(0, Math.min(1, ((fromPoint.x - entity.vertices[i].x) * dx + (fromPoint.y - entity.vertices[i].y) * dy) / (len * len)));
+        points.push({
+          x: entity.vertices[i].x + t * dx,
+          y: entity.vertices[i].y + t * dy
+        });
+      }
+      return points;
+    default:
+      return [];
+  }
+}
+
+/**
+ * 엔티티에서 TANGENT(접선) 스냅 포인트를 계산합니다.
+ */
+function getTangentSnapPoints(entity: Entity, fromPoint: Point): Point[] {
+  switch (entity.type) {
+    case "CIRCLE":
+      if (entity.center && entity.radius !== undefined) {
+        const dx = fromPoint.x - entity.center.x;
+        const dy = fromPoint.y - entity.center.y;
+        const dist = Math.hypot(dx, dy);
+        if (dist < 1e-10) return [];
+        const angle = Math.atan2(dy, dx);
+        return [{
+          x: entity.center.x + entity.radius * Math.cos(angle),
+          y: entity.center.y + entity.radius * Math.sin(angle)
+        }];
+      }
+      return [];
+    case "ARC":
+      if (entity.center && entity.radius !== undefined) {
+        const dx = fromPoint.x - entity.center.x;
+        const dy = fromPoint.y - entity.center.y;
+        const dist = Math.hypot(dx, dy);
+        if (dist < 1e-10) return [];
+        const angle = Math.atan2(dy, dx);
+        return [{
+          x: entity.center.x + entity.radius * Math.cos(angle),
+          y: entity.center.y + entity.radius * Math.sin(angle)
+        }];
+      }
+      return [];
+    default:
+      return [];
+  }
 }
 
 /**
@@ -292,6 +395,44 @@ export function createSnapEngine(options: SnapEngineOptions = {}) {
 
     if (candidates.length === 0) return null;
 
+    // PERPENDICULAR 스냅 처리
+    if (enabledTypes.includes(SNAP_TYPES.PERPENDICULAR)) {
+      for (const entity of entities) {
+        const perpPoints = getPerpendicularSnapPoints(entity, screenPoint);
+        for (const pp of perpPoints) {
+          const dist = distance(screenPoint, pp);
+          if (dist <= tolerance) {
+            candidates.push({
+              point: pp,
+              type: SNAP_TYPES.PERPENDICULAR,
+              distance: dist,
+              priority: SNAP_PRIORITY[SNAP_TYPES.PERPENDICULAR],
+              entityId: entity.id
+            });
+          }
+        }
+      }
+    }
+
+    // TANGENT 스냅 처리
+    if (enabledTypes.includes(SNAP_TYPES.TANGENT)) {
+      for (const entity of entities) {
+        const tangentPoints = getTangentSnapPoints(entity, screenPoint);
+        for (const tp of tangentPoints) {
+          const dist = distance(screenPoint, tp);
+          if (dist <= tolerance) {
+            candidates.push({
+              point: tp,
+              type: SNAP_TYPES.TANGENT,
+              distance: dist,
+              priority: SNAP_PRIORITY[SNAP_TYPES.TANGENT],
+              entityId: entity.id
+            });
+          }
+        }
+      }
+    }
+
     candidates.sort((a, b) => {
       if (b.priority !== a.priority) return b.priority - a.priority;
       return a.distance - b.distance;
@@ -313,6 +454,12 @@ export function createSnapEngine(options: SnapEngineOptions = {}) {
           break;
         case SNAP_TYPES.MIDPOINT:
           points = getMidpointSnapPoints(entity);
+          break;
+        case SNAP_TYPES.PERPENDICULAR:
+          points = getPerpendicularSnapPoints(entity, screenPoint);
+          break;
+        case SNAP_TYPES.TANGENT:
+          points = getTangentSnapPoints(entity, screenPoint);
           break;
         default:
           points = [];

--- a/tests/snap-engine.test.ts
+++ b/tests/snap-engine.test.ts
@@ -7,11 +7,11 @@ import fs from "node:fs/promises";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
-// snap-engine.js 파일이 존재해야 함
-test("snap-engine.js 파일이 존재해야 함", async () => {
+// snap-engine.ts 파일이 존재해야 함
+test("snap-engine.ts 파일이 존재해야 함", async () => {
   const filePath = path.resolve(__dirname, "../packages/sdk-react/src/tools/snap-engine.ts");
   const exists = await fs.access(filePath).then(() => true).catch(() => false);
-  assert.ok(exists, "snap-engine.js 파일이 존재해야 함");
+  assert.ok(exists, "snap-engine.ts 파일이 존재해야 함");
 });
 
 // 끝점 스냅 함수가 있어야 함
@@ -52,4 +52,90 @@ test("스냅 엔진 생성 함수가 있어야 함", async () => {
     content.includes("createSnapEngine") || content.includes("SnapEngine") || content.includes("snap"),
     "스냅 엔진 생성 함수가 있어야 함"
   );
+});
+
+// =====================================================================
+// 1단계 확장: PERPENDICULAR, TANGENT, NEAREST 스냅
+// =====================================================================
+
+// PERPENDICULAR 스냅 타입이 정의되어 있어야 함
+test("PERPENDICULAR 스냅 타입이 정의되어 있어야 함", async () => {
+  const filePath = path.resolve(__dirname, "../packages/sdk-react/src/tools/snap-engine.ts");
+  const content = await fs.readFile(filePath, "utf8");
+  assert.ok(
+    content.includes('"perpendicular"') || content.includes("'perpendicular'") || content.includes("PERPENDICULAR"),
+    "PERPENDICULAR 스냅 타입이 정의되어 있어야 함"
+  );
+});
+
+// TANGENT 스냅 타입이 정의되어 있어야 함
+test("TANGENT 스냅 타입이 정의되어 있어야 함", async () => {
+  const filePath = path.resolve(__dirname, "../packages/sdk-react/src/tools/snap-engine.ts");
+  const content = await fs.readFile(filePath, "utf8");
+  assert.ok(
+    content.includes('"tangent"') || content.includes("'tangent'") || content.includes("TANGENT"),
+    "TANGENT 스냅 타입이 정의되어 있어야 함"
+  );
+});
+
+// NEAREST 스냅이 정의되어 있어야 함
+test("NEAREST 스냅 타입이 정의되어 있어야 함", async () => {
+  const filePath = path.resolve(__dirname, "../packages/sdk-react/src/tools/snap-engine.ts");
+  const content = await fs.readFile(filePath, "utf8");
+  assert.ok(
+    content.includes("NEAREST") || content.includes("nearest"),
+    "NEAREST 스냅 타입이 정의되어 있어야 함"
+  );
+});
+
+// PERPENDICULAR 스냅 계산 함수가 있어야 함
+test("PERPENDICULAR(수직) 스냅 계산 함수가 있어야 함", async () => {
+  const filePath = path.resolve(__dirname, "../packages/sdk-react/src/tools/snap-engine.ts");
+  const content = await fs.readFile(filePath, "utf8");
+  assert.ok(
+    content.includes("perpendicular") || content.includes("Perpendicular"),
+    "PERPENDICULAR(수직) 스냅 계산 함수가 있어야 함"
+  );
+});
+
+// TANGENT 스냅 계산 함수가 있어야 함
+test("TANGENT(접선) 스냅 계산 함수가 있어야 함", async () => {
+  const filePath = path.resolve(__dirname, "../packages/sdk-react/src/tools/snap-engine.ts");
+  const content = await fs.readFile(filePath, "utf8");
+  assert.ok(
+    content.includes("tangent") || content.includes("Tangent"),
+    "TANGENT(접선) 스냅 계산 함수가 있어야 함"
+  );
+});
+
+// NEAREST 스냅 계산 함수가 있어야 함
+test("NEAREST(근접점) 스냅 계산 함수가 있어야 함", async () => {
+  const filePath = path.resolve(__dirname, "../packages/sdk-react/src/tools/snap-engine.ts");
+  const content = await fs.readFile(filePath, "utf8");
+  // NEAREST는 스냅 인프라에서 이미 처리됨 (기존 snap type)
+  assert.ok(
+    content.includes("NEAREST") || content.includes("nearest"),
+    "NEAREST 스냅 타입이 정의되어 있어야 함"
+  );
+});
+
+// SNAP_TYPES에 3가지 새로운 스냅이 모두 포함되어 있어야 함
+test("SNAP_TYPES에 PERPENDICULAR, TANGENT, NEAREST가 모두 포함되어 있어야 함", async () => {
+  const filePath = path.resolve(__dirname, "../packages/sdk-react/src/tools/snap-engine.ts");
+  const content = await fs.readFile(filePath, "utf8");
+  assert.ok(content.includes("PERPENDICULAR"), "PERPENDICULAR 타입 필요");
+  assert.ok(content.includes("TANGENT"), "TANGENT 타입 필요");
+  assert.ok(content.includes("NEAREST"), "NEAREST 타입 필요");
+});
+
+// SNAP_PRIORITY에 새로운 스냅 타입의 우선순위가 정의되어 있어야 함
+test("SNAP_PRIORITY에 새로운 스냅 타입의 우선순위가 정의되어 있어야 함", async () => {
+  const filePath = path.resolve(__dirname, "../packages/sdk-react/src/tools/snap-engine.ts");
+  const content = await fs.readFile(filePath, "utf8");
+  const perpMatch = content.match(/PERPENDICULAR[^:]*:\s*\d+/);
+  const tangMatch = content.match(/TANGENT[^:]*:\s*\d+/);
+  const nearMatch = content.match(/NEAREST[^:]*:\s*\d+/);
+  assert.ok(perpMatch, "PERPENDICULAR 우선순위 필요");
+  assert.ok(tangMatch, "TANGENT 우선순위 필요");
+  assert.ok(nearMatch, "NEAREST 우선순위 필요");
 });


### PR DESCRIPTION
Phase 1 CAD tools:
- Add PERPENDICULAR snap type with priority 85
- Add TANGENT snap type with priority 75
- Add getPerpendicularSnapPoints() for line/polyline entities
- Add getTangentSnapPoints() for circle/arc entities
- Integrate new snap types into findSnapPoint and findSnapPointOfType
- Add TDD tests for new snap types

Issue #55 — Phase 5