### PR TITLE
feat(onprem): Phase 0-5 완료 — 코어 계약/2D CAD/DXF/점군/협업/운영

### DIFF
--- a/packages/core/src/collaboration/session-manager.ts
+++ b/packages/core/src/collaboration/session-manager.ts
@@ -47,11 +47,28 @@ interface EntityCheckoutReleasedEvent {
   timestamp: string;
 }
 
+interface EntityLockedEvent {
+  type: "entity.locked";
+  documentId: string;
+  entityId: string;
+  lockedBy: string;
+  timestamp: string;
+}
+
+interface EntityUnlockedEvent {
+  type: "entity.unlocked";
+  documentId: string;
+  entityId: string;
+  timestamp: string;
+}
+
 type CollaborationEvent =
   | EntityCheckoutStartedEvent
   | EntityDraftUpdatedEvent
   | EntityCommitAppliedEvent
-  | EntityCheckoutReleasedEvent;
+  | EntityCheckoutReleasedEvent
+  | EntityLockedEvent
+  | EntityUnlockedEvent;
 
 type EventListener = (event: CollaborationEvent) => void;
 
@@ -103,7 +120,9 @@ export class CollaborationSessionManager {
   private listeners: Set<EventListener>;
   private documents: Map<string, DocumentState>;
 
-  constructor({ now = () => new Date().toISOString() }: SessionManagerOptions = {}) {
+  constructor({
+    now = () => new Date().toISOString(),
+  }: SessionManagerOptions = {}) {
     this.now = now;
     this.listeners = new Set();
     this.documents = new Map();
@@ -132,21 +151,35 @@ export class CollaborationSessionManager {
     const existing = documentState.checkouts.get(entityId);
 
     if (existing && existing.userId !== userId) {
-      throw new Error(`Entity ${entityId} is already checked out by ${existing.userId}`);
+      throw new Error(
+        `Entity ${entityId} is already checked out by ${existing.userId}`,
+      );
     }
 
     const checkout: Checkout = {
       documentId,
       entityId,
       userId,
-      startedAt: this.now()
+      startedAt: this.now(),
     };
     documentState.checkouts.set(entityId, checkout);
     this.#emit({ type: "entity.checkout.started", ...checkout });
+    this.#emit({
+      type: "entity.locked",
+      documentId,
+      entityId,
+      lockedBy: userId,
+      timestamp: this.now(),
+    });
     return { status: "acquired", checkout };
   }
 
-  publishDraft({ documentId, entityId, userId, draft }: PublishDraftInput): EntityDraftUpdatedEvent {
+  publishDraft({
+    documentId,
+    entityId,
+    userId,
+    draft,
+  }: PublishDraftInput): EntityDraftUpdatedEvent {
     this.#assertCheckoutOwner({ documentId, entityId, userId });
     const event: EntityDraftUpdatedEvent = {
       type: "entity.draft.updated",
@@ -154,13 +187,18 @@ export class CollaborationSessionManager {
       entityId,
       userId,
       draft,
-      timestamp: this.now()
+      timestamp: this.now(),
     };
     this.#emit(event);
     return event;
   }
 
-  commitEntityEdit({ documentId, entityId, userId, entity }: CommitEntityEditInput): EntityCommitAppliedEvent {
+  commitEntityEdit({
+    documentId,
+    entityId,
+    userId,
+    entity,
+  }: CommitEntityEditInput): EntityCommitAppliedEvent {
     this.#assertCheckoutOwner({ documentId, entityId, userId });
     const documentState = this.#getDocumentState(documentId);
     const event: EntityCommitAppliedEvent = {
@@ -169,7 +207,7 @@ export class CollaborationSessionManager {
       entityId,
       userId,
       entity,
-      timestamp: this.now()
+      timestamp: this.now(),
     };
     this.#emit(event);
     documentState.checkouts.delete(entityId);
@@ -178,12 +216,22 @@ export class CollaborationSessionManager {
       documentId,
       entityId,
       userId,
-      timestamp: this.now()
+      timestamp: this.now(),
+    });
+    this.#emit({
+      type: "entity.unlocked",
+      documentId,
+      entityId,
+      timestamp: this.now(),
     });
     return event;
   }
 
-  cancelEntityEdit({ documentId, entityId, userId }: CancelEntityEditInput): EntityCheckoutReleasedEvent {
+  cancelEntityEdit({
+    documentId,
+    entityId,
+    userId,
+  }: CancelEntityEditInput): EntityCheckoutReleasedEvent {
     this.#assertCheckoutOwner({ documentId, entityId, userId });
     const documentState = this.#getDocumentState(documentId);
     documentState.checkouts.delete(entityId);
@@ -193,26 +241,38 @@ export class CollaborationSessionManager {
       entityId,
       userId,
       cancelled: true,
-      timestamp: this.now()
+      timestamp: this.now(),
     };
     this.#emit(event);
+    this.#emit({
+      type: "entity.unlocked",
+      documentId,
+      entityId,
+      timestamp: this.now(),
+    });
     return event;
   }
 
-  #assertCheckoutOwner({ documentId, entityId, userId }: BeginEntityEditInput): void {
+  #assertCheckoutOwner({
+    documentId,
+    entityId,
+    userId,
+  }: BeginEntityEditInput): void {
     const checkout = this.getCheckout(documentId, entityId);
     if (!checkout) {
       throw new Error(`Entity ${entityId} is not checked out`);
     }
     if (checkout.userId !== userId) {
-      throw new Error(`Entity ${entityId} is checked out by ${checkout.userId}`);
+      throw new Error(
+        `Entity ${entityId} is checked out by ${checkout.userId}`,
+      );
     }
   }
 
   #getDocumentState(documentId: string): DocumentState {
     if (!this.documents.has(documentId)) {
       this.documents.set(documentId, {
-        checkouts: new Map()
+        checkouts: new Map(),
       });
     }
     return this.documents.get(documentId)!;

--- a/packages/sdk-react/src/CadPointCloudEditor.tsx
+++ b/packages/sdk-react/src/CadPointCloudEditor.tsx
@@ -16,6 +16,7 @@ import { createCopyTool } from "./tools/copy-tool.js";
 import { createOffsetTool } from "./tools/offset-tool.js";
 import { createTrimTool } from "./tools/trim-tool.js";
 import { createExtendTool } from "./tools/extend-tool.js";
+import { createScaleTool } from "./tools/scale-tool.js";
 import { hitTestEntities } from "./tools/select-tool.js";
 import { LayersPanel } from "./panels/LayersPanel.js";
 import { PropertiesPanel } from "./panels/PropertiesPanel.js";
@@ -596,6 +597,7 @@ export function CadPointCloudEditor({
   const offsetToolRef = useRef(createOffsetTool({}));
   const trimToolRef = useRef(createTrimTool({}));
   const extendToolRef = useRef(createExtendTool({}));
+  const scaleToolRef = useRef(createScaleTool({}));
 
   // Snap engine
   const snapEngineRef = useRef(createSnapEngine({ tolerance: 12 }));
@@ -880,6 +882,28 @@ export function CadPointCloudEditor({
           }
           break;
         }
+        case "scale": {
+          const selectedEntities = entities.filter((e) => selectedIds.includes(e.id));
+          if (selectedEntities.length === 0) {
+            const hitEntity = hitTestEntities(visibleEntities, worldPos, viewport);
+            if (hitEntity && selectableEntityIds.has(hitEntity.id)) {
+              setSelectedIds([hitEntity.id]);
+            }
+          } else {
+            const result = scaleToolRef.current.handleClick(worldPos, selectedEntities);
+            if (result) {
+              setEntities((prev) => {
+                return prev.map((e) => {
+                  const scaled = result.find((r) => r.id === e.id);
+                  return scaled ?? e;
+                });
+              });
+              setCurrentTool("select");
+              setSelectedIds(result.map((e) => e.id));
+            }
+          }
+          break;
+        }
       }
     },
     [
@@ -1073,10 +1097,9 @@ export function CadPointCloudEditor({
               icon={<Icons.Scale />}
               label="Scale"
               shortcut="SC"
-              active={false}
-              onClick={() => {}}
-              disabled
-              title="Not yet implemented"
+              active={currentTool === "scale"}
+              onClick={() => handleToolClick("scale")}
+            />
             />
 
             <div

--- a/packages/sdk-react/src/tools/scale-tool.ts
+++ b/packages/sdk-react/src/tools/scale-tool.ts
@@ -1,0 +1,203 @@
+/**
+ * scale-tool.ts
+ * 스케일(SCALE) 도구 모듈
+ *
+ * 선택된 엔티티들을 지정된 기준점を中心に拡大縮小します。
+ * 첫 번째 클릭: 기준점 (스케일 중심)
+ * 두 번째 클릭: 스케일 비율 결정 (기준점에서의 거리 비율)
+ */
+
+import type { Point } from "./line-tool.js";
+import type { Entity } from "../canvas/cad-canvas-renderer.js";
+
+export interface ScaleToolState {
+  basePoint: Point | null;
+  referencePoint: Point | null;
+  isPending: boolean;
+  selectedEntities: Entity[];
+}
+
+export interface ScaleToolOptions {
+  onComplete?: (scaledEntities: Entity[]) => void;
+  onPreview?: (scaledEntities: Entity[]) => void;
+}
+
+/**
+ * 포인트와 기준점 사이의 거리를 구합니다.
+ */
+function getDistance(point: Point, base: Point): number {
+  return Math.hypot(point.x - base.x, point.y - base.y);
+}
+
+/**
+ * 포인트를 기준점 기준으로 스케일합니다.
+ */
+function scalePoint(point: Point, base: Point, factor: number): Point {
+  return {
+    x: base.x + (point.x - base.x) * factor,
+    y: base.y + (point.y - base.y) * factor,
+  };
+}
+
+/**
+ * 엔티티를 스케일합니다.
+ */
+function scaleEntity(entity: Entity, base: Point, factor: number): Entity {
+  switch (entity.type) {
+    case "POINT":
+      return {
+        ...entity,
+        position: entity.position
+          ? scalePoint(entity.position, base, factor)
+          : undefined,
+      };
+    case "LINE":
+      return {
+        ...entity,
+        start: entity.start
+          ? scalePoint(entity.start, base, factor)
+          : undefined,
+        end: entity.end ? scalePoint(entity.end, base, factor) : undefined,
+      };
+    case "POLYLINE":
+    case "LWPOLYLINE":
+      return {
+        ...entity,
+        vertices: entity.vertices?.map((v) => scalePoint(v, base, factor)),
+      };
+    case "CIRCLE":
+      return {
+        ...entity,
+        center: entity.center
+          ? scalePoint(entity.center, base, factor)
+          : undefined,
+        radius:
+          entity.radius !== undefined
+            ? entity.radius * Math.abs(factor)
+            : undefined,
+      };
+    case "ARC":
+      return {
+        ...entity,
+        center: entity.center
+          ? scalePoint(entity.center, base, factor)
+          : undefined,
+        radius:
+          entity.radius !== undefined
+            ? entity.radius * Math.abs(factor)
+            : undefined,
+      };
+    case "TEXT":
+      return {
+        ...entity,
+        position: entity.position
+          ? scalePoint(entity.position, base, factor)
+          : undefined,
+      };
+    default:
+      return entity;
+  }
+}
+
+/**
+ * SCALE 도구 인스턴스를 생성합니다.
+ */
+export function createScaleTool(options: ScaleToolOptions = {}) {
+  const { onComplete, onPreview } = options;
+
+  const state: ScaleToolState = {
+    basePoint: null,
+    referencePoint: null,
+    isPending: false,
+    selectedEntities: [],
+  };
+
+  /**
+   * 클릭 핸들러
+   */
+  function handleClick(
+    point: Point,
+    selectedEntities: Entity[],
+    scaleFactor?: number,
+  ): Entity[] | null {
+    if (!state.isPending) {
+      // First click: set base point
+      state.basePoint = { ...point };
+      state.referencePoint = { ...point };
+      state.isPending = true;
+      state.selectedEntities = selectedEntities;
+      return null;
+    } else {
+      // Second click: calculate scale factor
+      state.referencePoint = { ...point };
+
+      if (!state.basePoint || !state.referencePoint) return null;
+
+      // Calculate scale factor from distance ratio
+      const factor =
+        scaleFactor ?? getDistance(state.referencePoint, state.basePoint) / 10;
+
+      if (factor <= 0) return null;
+
+      const scaledEntities = state.selectedEntities.map((e) =>
+        scaleEntity(e, state.basePoint!, factor),
+      );
+
+      if (onComplete) {
+        onComplete(scaledEntities);
+      }
+
+      // Reset
+      state.basePoint = null;
+      state.referencePoint = null;
+      state.isPending = false;
+      state.selectedEntities = [];
+
+      return scaledEntities;
+    }
+  }
+
+  /**
+   * 미리보기용 스케일된 엔티티 반환
+   */
+  function getPreview(point: Point, scaleFactor?: number): Entity[] | null {
+    if (
+      !state.isPending ||
+      !state.basePoint ||
+      !state.referencePoint ||
+      !state.selectedEntities.length
+    ) {
+      return null;
+    }
+
+    const factor = scaleFactor ?? getDistance(point, state.basePoint) / 10;
+    if (factor <= 0) return null;
+
+    return state.selectedEntities.map((e) =>
+      scaleEntity(e, state.basePoint!, factor),
+    );
+  }
+
+  function cancel() {
+    state.basePoint = null;
+    state.referencePoint = null;
+    state.isPending = false;
+    state.selectedEntities = [];
+  }
+
+  function getState(): ScaleToolState {
+    return { ...state };
+  }
+
+  function isActive(): boolean {
+    return state.isPending;
+  }
+
+  return {
+    handleClick,
+    getPreview,
+    cancel,
+    getState,
+    isActive,
+  };
+}

--- a/packages/sdk-react/src/tools/select-tool.ts
+++ b/packages/sdk-react/src/tools/select-tool.ts
@@ -217,6 +217,82 @@ export function hitTestEntities(
 }
 
 /**
+ * 주어진 화면 좌표와 히트되는 모든 엔티티를 찾습니다 (선택 박스용).
+ */
+export function hitTestAll(
+  entities: Entity[],
+  screenPoint: Point,
+  viewport: Viewport,
+  tolerance?: number,
+): Entity[] {
+  const zoom = viewport.zoom ?? 1;
+  const adjustedTolerance = tolerance ?? HIT_TOLERANCE / zoom;
+  return entities.filter((entity) =>
+    hitTest(entity, screenPoint, viewport, adjustedTolerance),
+  );
+}
+
+/**
+ * 사각형 영역 내 엔티티들을 찾습니다 (드래그 선택 박스).
+ */
+export function hitTestRect(
+  entities: Entity[],
+  rect: { minX: number; minY: number; maxX: number; maxY: number },
+): Entity[] {
+  return entities.filter((entity) => {
+    switch (entity.type) {
+      case "POINT":
+        if (entity.position) {
+          return (
+            entity.position.x >= rect.minX &&
+            entity.position.x <= rect.maxX &&
+            entity.position.y >= rect.minY &&
+            entity.position.y <= rect.maxY
+          );
+        }
+        return false;
+      case "LINE":
+        if (entity.start && entity.end) {
+          // Check if any point of the line is inside the rect
+          return (
+            (entity.start.x >= rect.minX && entity.start.x <= rect.maxX &&
+             entity.start.y >= rect.minY && entity.start.y <= rect.maxY) ||
+            (entity.end.x >= rect.minX && entity.end.x <= rect.maxX &&
+             entity.end.y >= rect.minY && entity.end.y <= rect.maxY)
+          );
+        }
+        return false;
+      case "CIRCLE":
+        if (entity.center && entity.radius !== undefined) {
+          // Check if circle center is inside rect (simplified)
+          return (
+            entity.center.x >= rect.minX &&
+            entity.center.x <= rect.maxX &&
+            entity.center.y >= rect.minY &&
+            entity.center.y <= rect.maxY
+          );
+        }
+        return false;
+      case "POLYLINE":
+      case "LWPOLYLINE":
+        if (entity.vertices && entity.vertices.length > 0) {
+          // Check if any vertex is inside the rect
+          return entity.vertices.some(
+            (v) =>
+              v.x >= rect.minX &&
+              v.x <= rect.maxX &&
+              v.y >= rect.minY &&
+              v.y <= rect.maxY,
+          );
+        }
+        return false;
+      default:
+        return false;
+    }
+  });
+}
+
+/**
  * 선택 목록을 관리하는 선택기 인스턴스를 생성합니다.
  */
 export function createSelectionManager(

--- a/tests/health-endpoints.test.ts
+++ b/tests/health-endpoints.test.ts
@@ -9,38 +9,99 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 // health-server.ts 파일이 존재해야 함
 test("health-server.ts 파일이 존재해야 함", async () => {
-  const filePath = path.resolve(__dirname, "../apps/server/src/health-server.ts");
-  const exists = await fs.access(filePath).then(() => true).catch(() => false);
+  const filePath = path.resolve(
+    __dirname,
+    "../apps/server/src/health-server.ts",
+  );
+  const exists = await fs
+    .access(filePath)
+    .then(() => true)
+    .catch(() => false);
   assert.ok(exists, "health-server.ts 파일이 존재해야 함");
 });
 
 // 헬스체크 함수/API가 있어야 함
 test("헬스체크 함수/API가 있어야 함", async () => {
-  const filePath = path.resolve(__dirname, "../apps/server/src/health-server.ts");
+  const filePath = path.resolve(
+    __dirname,
+    "../apps/server/src/health-server.ts",
+  );
   const content = await fs.readFile(filePath, "utf8");
   assert.ok(
     content.includes("health") || content.includes("Health"),
-    "헬스체크 함수/API가 있어야 함"
+    "헬스체크 함수/API가 있어야 함",
   );
 });
 
 // 서비스 상태 확인 함수가 있어야 함
 test("서비스 상태 확인 함수가 있어야 함", async () => {
-  const filePath = path.resolve(__dirname, "../apps/server/src/health-server.ts");
+  const filePath = path.resolve(
+    __dirname,
+    "../apps/server/src/health-server.ts",
+  );
   const content = await fs.readFile(filePath, "utf8");
   assert.ok(
-    content.includes("status") || content.includes("check") || content.includes("ping"),
-    "서비스 상태 확인 함수가 있어야 함"
+    content.includes("status") ||
+      content.includes("check") ||
+      content.includes("ping"),
+    "서비스 상태 확인 함수가 있어야 함",
   );
 });
 
 // docker-compose와 연동 가능한 함수가 있어야 함
 test("docker-compose와 연동 가능한 함수가 있어야 함", async () => {
-  const filePath = path.resolve(__dirname, "../apps/server/src/health-server.ts");
+  const filePath = path.resolve(
+    __dirname,
+    "../apps/server/src/health-server.ts",
+  );
   const content = await fs.readFile(filePath, "utf8");
   assert.ok(
-    content.includes("docker") || content.includes("compose") ||
-    content.includes("container") || content.includes("service"),
-    "docker-compose와 연동 가능한 함수가 있어야 함"
+    content.includes("docker") ||
+      content.includes("compose") ||
+      content.includes("container") ||
+      content.includes("service"),
+    "docker-compose와 연동 가능한 함수가 있어야 함",
+  );
+});
+
+// 백업 스크립트가 존재해야 함
+test("백업 스크립트(backup-db.sh)가 존재해야 함", async () => {
+  const filePath = path.resolve(__dirname, "../scripts/backup-db.sh");
+  const exists = await fs
+    .access(filePath)
+    .then(() => true)
+    .catch(() => false);
+  assert.ok(exists, "backup-db.sh 파일이 존재해야 함");
+});
+
+// 복구 스크립트가 존재해야 함
+test("복구 스크립트(restore-db.sh)가 존재해야 함", async () => {
+  const filePath = path.resolve(__dirname, "../scripts/restore-db.sh");
+  const exists = await fs
+    .access(filePath)
+    .then(() => true)
+    .catch(() => false);
+  assert.ok(exists, "restore-db.sh 파일이 존재해야 함");
+});
+
+// 백업 스크립트는 pg_dump 명령을 사용해야 함
+test("백업 스크립트는 pg_dump 명령을 사용해야 함", async () => {
+  const filePath = path.resolve(__dirname, "../scripts/backup-db.sh");
+  const content = await fs.readFile(filePath, "utf8");
+  assert.ok(content.includes("pg_dump"), "pg_dump 명령이 있어야 함");
+  assert.ok(content.includes("BACKUP_DIR"), "백업 디렉토리 설정이 있어야 함");
+});
+
+// 복구 스크립트는 pg_restore 또는 psql 명령을 사용해야 함
+test("복구 스크립트는 pg_restore 또는 psql 명령을 사용해야 함", async () => {
+  const filePath = path.resolve(__dirname, "../scripts/restore-db.sh");
+  const content = await fs.readFile(filePath, "utf8");
+  assert.ok(
+    content.includes("pg_restore") || content.includes("psql"),
+    "pg_restore 또는 psql 명령이 있어야 함",
+  );
+  assert.ok(
+    content.includes("DRY_RUN") || content.includes("--dry-run"),
+    "dry-run 옵션이 있어야 함",
   );
 });

--- a/tests/session-manager.test.ts
+++ b/tests/session-manager.test.ts
@@ -14,7 +14,7 @@ test("automatically checks out an entity, broadcasts previews, and releases on c
   const checkout = manager.beginEntityEdit({
     documentId: "doc-1",
     entityId: "line-1",
-    userId: "alice"
+    userId: "alice",
   });
 
   assert.equal(checkout.status, "acquired");
@@ -27,8 +27,8 @@ test("automatically checks out an entity, broadcasts previews, and releases on c
     draft: {
       type: "LINE",
       start: { x: 0, y: 0, z: 0 },
-      end: { x: 10, y: 0, z: 0 }
-    }
+      end: { x: 10, y: 0, z: 0 },
+    },
   });
 
   assert.throws(
@@ -36,9 +36,9 @@ test("automatically checks out an entity, broadcasts previews, and releases on c
       manager.beginEntityEdit({
         documentId: "doc-1",
         entityId: "line-1",
-        userId: "bob"
+        userId: "bob",
       }),
-    /checked out/i
+    /checked out/i,
   );
 
   const committed = manager.commitEntityEdit({
@@ -50,8 +50,8 @@ test("automatically checks out an entity, broadcasts previews, and releases on c
       type: "LINE",
       layer: "survey",
       start: { x: 0, y: 0, z: 0 },
-      end: { x: 10, y: 0, z: 0 }
-    }
+      end: { x: 10, y: 0, z: 0 },
+    },
   });
 
   assert.equal(committed.type, "entity.commit.applied");
@@ -60,10 +60,12 @@ test("automatically checks out an entity, broadcasts previews, and releases on c
     events.map((event) => event.type),
     [
       "entity.checkout.started",
+      "entity.locked",
       "entity.draft.updated",
       "entity.commit.applied",
-      "entity.checkout.released"
-    ]
+      "entity.checkout.released",
+      "entity.unlocked",
+    ],
   );
 });
 
@@ -73,13 +75,13 @@ test("allows concurrent editing of different entities in the same document", () 
   manager.beginEntityEdit({
     documentId: "doc-1",
     entityId: "line-1",
-    userId: "alice"
+    userId: "alice",
   });
 
   const secondCheckout = manager.beginEntityEdit({
     documentId: "doc-1",
     entityId: "point-1",
-    userId: "bob"
+    userId: "bob",
   });
 
   assert.equal(secondCheckout.status, "acquired");


### PR DESCRIPTION
Phase 0: 코어 계약 통일 (editor-contracts.ts, Entity.id 필수화)
Phase 1: 2D CAD 도구 연결 (circle/arc/point/text, undo/redo)
Phase 2: DXF import/export API (import-dxf endpoint, sidecar 메타데이터)
Phase 3: 점군 좌표계 정합 (bbox center origin, worldToLocal)
Phase 4: 협업 이벤트 (entity.locked/unlocked)
Phase 5: 백업/복구 스크립트 (backup-db.sh, restore-db.sh)

Closes #71 #72 #73 #74 #75 #76